### PR TITLE
Splits installers and allows 4.9.0 install

### DIFF
--- a/FileBot/README.md
+++ b/FileBot/README.md
@@ -1,7 +1,18 @@
-If you'd like to run the latest version of FileBot (4.8.5 as of 12/2/2019) and you've purchased a license, you can install it using the instructions below:
+##FileBot
 
-1. `mkdir filebot-portable && cd filebot-portable`
-2. `sh -xu <<< "$(curl -fsSL https://raw.githubusercontent.com/no5tyle/UltraSeedbox-Scripts/master/FileBot/filebot-installer.sh)"`
+###Version 4.9.0
+If you'd like to run the latest version of FileBot (4.9.0 as of 3/24/2020) and you've purchased a license, you can install it using the instructions below:
+
+1. `sh -xu <<< "$(curl -fsSL https://raw.githubusercontent.com/no5tyle/UltraSeedbox-Scripts/master/FileBot/filebot-490-installer.sh)"`
 3. `filebot --license /path/to/FileBot_License_P1234567.psm`
 
 Nothing more needs to be done. If you're using FileBot for your torrent client post-processing, that will now use this version of FileBot as well. Enjoy!
+
+###Version 4.8.5
+If you'd like to run the previous version of FileBot and you've purchased a license, you can install it using the instructions below:
+
+1. `mkdir filebot-portable && cd filebot-portable`
+2. `sh -xu <<< "$(curl -fsSL https://raw.githubusercontent.com/no5tyle/UltraSeedbox-Scripts/master/FileBot/filebot-485-installer.sh)"`
+3. `filebot --license /path/to/FileBot_License_P1234567.psm`
+
+That's it!

--- a/FileBot/filebot-485-installer.sh
+++ b/FileBot/filebot-485-installer.sh
@@ -20,7 +20,7 @@ tar xvf "$PACKAGE_FILE"
 sed -i '/#!\/bin\/sh/a export JAVA_OPTS=\"-Xmx1536m\"' filebot.sh
 
 # Check if filebot.sh works
-"$PWD/filebot.sh" -script fn:sysinfo
+"$PWD/filebot.sh" -script https://raw.githubusercontent.com/no5tyle/UltraSeedbox-Scripts/master/FileBot/usbsysinfo.groovy
 
 # Link into user $PATH
 ln -sf "$PWD/filebot.sh" $HOME/bin/filebot

--- a/FileBot/filebot-490-installer.sh
+++ b/FileBot/filebot-490-installer.sh
@@ -1,0 +1,45 @@
+#!/bin/sh -xu
+# Based on the official tar installer: https://raw.githubusercontent.com/filebot/plugins/master/installer/tar.sh
+# Includes installer for Java 11, required to run FileBot 4.9+
+
+# Set FileBot version and URLs
+PACKAGE_VERSION=4.9.0
+PACKAGE_SHA256=$(curl -fsSL https://raw.githubusercontent.com/filebot/website/master/get.filebot.net/filebot/FileBot_$PACKAGE_VERSION/FileBot_$PACKAGE_VERSION-portable.tar.xz.sha256)
+PACKAGE_FILE=FileBot_$PACKAGE_VERSION-portable.tar.xz
+PACKAGE_URL=https://get.filebot.net/filebot/FileBot_$PACKAGE_VERSION/$PACKAGE_FILE
+
+# Create directory for all FileBot data and change working directory
+mkdir -p "$HOME"/filebot-latest && cd "$HOME"/filebot-latest
+
+# Fetch Java 11 binaries archive
+curl -o Java11.tar.gz "https://download.java.net/openjdk/jdk11/ri/openjdk-11+28_linux-x64_bin.tar.gz"
+
+# Extract Java 11 binaries and remove archive
+tar xf Java11.tar.gz && rm Java11.tar.gz
+
+# Download FileBot package
+curl -o "$PACKAGE_FILE" -z "$PACKAGE_FILE" "$PACKAGE_URL"
+
+# Check SHA-256 checksum
+echo "$PACKAGE_SHA256 *$PACKAGE_FILE" | sha256sum --check || exit 1
+
+# Extract FileBot archive
+tar xf "$PACKAGE_FILE"
+
+# Clean up FileBot files
+rm "$PACKAGE_FILE" reinstall-filebot.sh update-filebot.sh
+
+# Increase maximum amount of memory that can be allocated to the JVM heap
+sed -i '/#!\/bin\/sh/a export JAVA_OPTS=\"-Xmx1536m\"' filebot.sh
+
+# Use custom Java 11 installation to run FileBot
+sed -i '/^java/ s#java#'"$PWD"'\/jdk-11\/bin\/java#' filebot.sh
+
+# Check if filebot.sh works
+"$PWD/filebot.sh" -script https://raw.githubusercontent.com/no5tyle/UltraSeedbox-Scripts/master/FileBot/usbsysinfo.groovy
+
+# Link into user bin
+ln -sf "$PWD/filebot.sh" "$HOME"/bin/filebot
+
+# Check if the filebot command works
+filebot -version

--- a/FileBot/usbsysinfo.groovy
+++ b/FileBot/usbsysinfo.groovy
@@ -1,0 +1,17 @@
+#!/usr/bin/env filebot -script
+// Custom script to lessen the onslaught of information output during installation
+
+println Settings.getApplicationIdentifier()
+
+println 'Groovy: ' + groovy.lang.GroovySystem.getVersion()
+
+println 'JRE: ' + Settings.getJavaRuntimeIdentifier()
+
+println 'DATA: ' + ApplicationFolder.AppData.get()
+
+try {
+	print 'License: '
+	println Settings.LICENSE.check()
+} catch(Throwable error) {
+	println error.message
+}


### PR DESCRIPTION
• Version 4.9.0 install requires Java 11
• Java 11 installed within FileBot directory
• Custom FileBot script w/ reduced console output